### PR TITLE
Corrected ingress annotation formatting

### DIFF
--- a/chart/template-node-react/templates/ingress.yaml
+++ b/chart/template-node-react/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     app: {{ .Release.Name }}
   {{- if .Values.ingress.appid.enabled }}
   annotations:
-    ingress.bluemix.net/appid-auth: {{ printf "bindSecret=%s namespace=%s requestType=%s serviceName=%s" (required "AppId binding is required to enable auth on the ingress" .Values.appidBinding) $namespace $requestType $fullName }}
+    ingress.bluemix.net/appid-auth: {{ printf "bindSecret=%s namespace=%s requestType=%s serviceName=%s" (required "AppId binding is required to enable auth on the ingress" .Values.ingress.appid.binding.name) .Values.ingress.appid.binding.namespace $requestType $fullName }}
   {{- end}}
 spec:
 {{- if include "starter-kit-chart.tlsSecretName" . }}


### PR DESCRIPTION
Signed-off-by: Rick Osowski <rosowski@gmail.com>

Based on the instructions available at https://ibm-garage-cloud.github.io/ibm-garage-developer-guide/practical/inventory-part2/#securing-the-solution-with-app-id and the documentation available via https://cloud.ibm.com/docs/openshift?topic=openshift-ingress_annotation#appid-auth, the current Ingress annotation will not work for multiple reasons.

1.  There is no `.Values.appidBinding` field if you follow the instructions.  This should be `.Values.ingress.appid.binding.name` instead.
2. The `$namespace` desired is not the namespace of the deployment, as it is currently templated.  It needs to be the namespace of the binding secret (as per the ROKS documentation link above). This should be `.Values.ingress.appid.binding.namespace` instead.